### PR TITLE
Crash recovery docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -40,6 +40,8 @@
     * [Run a validator](blockchain/for-validators-nominators-and-stakers/run-a-validator.md)
     * [Non-technical run a validator](blockchain/for-validators-nominators-and-stakers/run-a-validator-non-technical.md)
     * [Staking](blockchain/for-validators-nominators-and-stakers/staking.md)
+    * [Update node](blockchain/for-validators-nominators-and-stakers/update.md)
+    * [Resync node](blockchain/for-validators-nominators-and-stakers/resync.md)
   * [For Developers & Testers](blockchain/for-developers-and-testers/README.md)
     * [Build, run & test using source code](blockchain/dev/dev.md)
     * [Run in Docker](blockchain/dev/docker.md)
@@ -47,3 +49,4 @@
     * [Runtime upgrade](blockchain/dev/runtime\_upgrade.md)
     * [Rust API docs](blockchain/dev/rust.md)
     * [Bootstrapping new testnet](blockchain/dev/bootstrapping\_new\_testnet.md)
+    * [Chain Crash Recovery Procedure](blockchain/dev/crash-recovery.md)

--- a/blockchain/dev/crash-recovery.md
+++ b/blockchain/dev/crash-recovery.md
@@ -1,0 +1,27 @@
+# Chain Crash Recovery Procedure
+
+This procedure should be performed by Liberland Blockchain Dev Team in case of chain failure that led to blocks not being produced.
+
+1. Identify the hash of the block that broke the runtime:
+   * If finalized, maybe chain explorer has it:
+       ```
+       query {
+         events(first:1,filter:{section:{equalTo:"system"},method:{equalTo:"CodeUpdated"}}, orderBy:BLOCK_NUMBER_DESC) {
+           nodes {
+             block {
+               number,
+               hash,
+               timestamp
+             }
+           }
+         }
+       }
+       ```
+    * Otherwise look for `system.CodeUpdated` event in recent blocks
+2. Update the chain specification to include hash of the block with `CodeUpdated` in `badBlocks`. **Notice:** this will revert all changed made in this block and all blocks that came after it, including things like transferring funds! This might cause consistency issues for exchanges, relayers, indexers that already processed these blocks in some way, especially if it was already finalized. Example:
+   ```
+     "badBlocks": ["0xab1f37b6306b2844320fba83152475efe06ab276cd46177da93e420079598609"],
+   ```
+3. Perform the standard release process. Remember to also build and publish new Docker image!
+4. Instruct all nodes in network (validators, exchanges, bridges, RPC endpoints, users) to perform [Node Update](../for-validators-nominators-and-stakers/update.md).
+5. If the removed block was already finalized, in addition to the update instruct all nodes to perform [Resync](../for-validators-nominators-and-stakers/resync.md).

--- a/blockchain/dev/crash-recovery.md
+++ b/blockchain/dev/crash-recovery.md
@@ -18,7 +18,7 @@ This procedure should be performed by Liberland Blockchain Dev Team in case of c
        }
        ```
     * Otherwise look for `system.CodeUpdated` event in recent blocks
-2. Update the chain specification to include hash of the block with `CodeUpdated` in `badBlocks`. **Notice:** this will revert all changed made in this block and all blocks that came after it, including things like transferring funds! This might cause consistency issues for exchanges, relayers, indexers that already processed these blocks in some way, especially if it was already finalized. Example:
+2. Update the JSON with chain specification in `specs/` to include hash of the block with `CodeUpdated` in `badBlocks`. **Notice:** this will revert all changed made in this block and all blocks that came after it, including things like transferring funds! This might cause consistency issues for exchanges, relayers, indexers that already processed these blocks in some way, especially if it was already finalized. Example:
    ```
      "badBlocks": ["0xab1f37b6306b2844320fba83152475efe06ab276cd46177da93e420079598609"],
    ```

--- a/blockchain/for-validators-nominators-and-stakers/resync.md
+++ b/blockchain/for-validators-nominators-and-stakers/resync.md
@@ -1,10 +1,13 @@
 # Resyncing node
 
 To resync your Liberland Node, you need to:
-1. stop the node
-2. remove the directory containing Liberland Node Database (`chains/mainnet/db`)
-3. restart the node
-4. wait until it resyncs
+1. If you're a validator and the chain is live and not stalled:
+   1. Stop validating using [Liberland dApp](https://blockchain.liberland.org/) or [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://mainnet.liberland.org#/legacy-staking/actions)
+   2. Make sure your node is not in [the active validator set](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmainnet.liberland.org#/legacy-staking)
+2. stop the node
+3. remove the directory containing Liberland Node Database (`chains/mainnet/db`)
+4. restart the node
+5. wait until it resyncs
 
 Node data directory structure is as follows:
 
@@ -26,7 +29,11 @@ For a detailed guide, please choose the proper instruction according to the meth
 
 # Automated script installs
 
-Run the following commands on your server:
+If your node is a validator and the chain is live and not stalled:
+1. Stop validating using [Liberland dApp](https://blockchain.liberland.org/) or [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://mainnet.liberland.org#/legacy-staking/actions)
+2. Make sure your node is not in [the active validator set](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmainnet.liberland.org#/legacy-staking)
+
+When your node is no longer a validator, or the chain is currently stalled, run the following commands on your server:
 
 ```
 systemctl stop liberland-validator
@@ -36,7 +43,11 @@ systemctl start liberland-validator
 
 # Docker installs
 
-If you followed the [Complete example of running a validator on mainnet](../dev/docker.md) guide, run these commands:
+If your node is a validator and the chain is live and not stalled:
+1. Stop validating using [Liberland dApp](https://blockchain.liberland.org/) or [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://mainnet.liberland.org#/legacy-staking/actions)
+2. Make sure your node is not in [the active validator set](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmainnet.liberland.org#/legacy-staking)
+
+When your node is no longer a validator, or the chain is currently stalled, run the following commands on your server:
 
 ```
 docker stop liberland
@@ -44,4 +55,4 @@ rm -rf $HOME/liberland_data/chains/mainnet/db
 docker start liberland
 ```
 
-If you run it in a custom way, adjust the container name and DB path accordingly.
+If you run it in a custom way, and not with the [Complete example of running a validator on mainnet](../dev/docker.md) guide, adjust the container name and DB path accordingly.

--- a/blockchain/for-validators-nominators-and-stakers/resync.md
+++ b/blockchain/for-validators-nominators-and-stakers/resync.md
@@ -1,0 +1,47 @@
+# Resyncing node
+
+To resync your Liberland Node, you need to:
+1. stop the node
+2. remove the directory containing Liberland Node Database (`chains/mainnet/db`)
+3. restart the node
+4. wait until it resyncs
+
+Node data directory structure is as follows:
+
+```
+chains
+└── mainnet
+    ├── db
+    ├── keystore
+    └── network
+```
+
+**DO NOT** remove `keystore` or `network` directories. Only remove the `db` directory.
+
+For a detailed guide, please choose the proper instruction according to the method used to install the node:
+
+* [Automated script](#automated-script-installs) (a.k.a. nodes installed with [this guide](./run-a-validator.md#option-1-automatic-script))
+* [Docker](#docker-installs)
+
+
+# Automated script installs
+
+Run the following commands on your server:
+
+```
+systemctl stop liberland-validator
+rm -rf /opt/liberland/data/chains/mainnet/db
+systemctl start liberland-validator
+```
+
+# Docker installs
+
+If you followed the [Complete example of running a validator on mainnet](../dev/docker.md) guide, run these commands:
+
+```
+docker stop liberland
+rm -rf $HOME/liberland_data/chains/mainnet/db
+docker start liberland
+```
+
+If you run it in a custom way, adjust the container name and DB path accordingly.

--- a/blockchain/for-validators-nominators-and-stakers/run-a-validator.md
+++ b/blockchain/for-validators-nominators-and-stakers/run-a-validator.md
@@ -55,7 +55,7 @@ bash install.sh
 
 The script will ask you for confirmation before every action. It will:
 * install dependencies
-* download liberland node and chain specification
+* download Liberland node
 * setup a systemd service, so that the node starts automatically
 * configure time synchronization
 * generate session keys for use in next step

--- a/blockchain/for-validators-nominators-and-stakers/update.md
+++ b/blockchain/for-validators-nominators-and-stakers/update.md
@@ -1,8 +1,6 @@
 # Node update guide
 
-Update requires:
-* updating to the latest node binary
-* updating to the latest chain specification
+Update requires updating to the latest node binary.
 
 For a detailed guide, please choose the proper instruction according to the method used to install the node:
 
@@ -37,14 +35,13 @@ If you followed the [Complete example of running a validator on mainnet](../dev/
     ```
 3. Recreate the container:
     ```
-    docker run --name liberland -d --network=host --restart always -v $HOME/liberland_data:/data liberland/blockchain-node:latest -d /data --chain /specs/mainnet.raw.json --validator
+    docker run --name liberland -d --network=host --restart always -v $HOME/liberland_data:/data liberland/blockchain-node:latest -d /data --chain mainnet --validator
     ```
 
 # Manual installs
 
 If you've installed manually, you need to:
 1. Download latest node binary (`linux_x86_build`) from the [releases page](https://github.com/liberland/liberland_substrate/releases)
-2. Download latest chain spec (`mainnet.raw.json`) from the [releases page](https://github.com/liberland/liberland_substrate/releases)
-3. Stop your node
-4. Replace the binary and spec files you're using with the downloaded ones
-5. Restart your node
+2. Stop your node
+3. Replace the binary you're using with the downloaded one
+4. Restart your node

--- a/blockchain/for-validators-nominators-and-stakers/update.md
+++ b/blockchain/for-validators-nominators-and-stakers/update.md
@@ -1,0 +1,50 @@
+# Node update guide
+
+Update requires:
+* updating to the latest node binary
+* updating to the latest chain specification
+
+For a detailed guide, please choose the proper instruction according to the method used to install the node:
+
+* [Automated script](#automated-script-installs) (a.k.a. nodes installed with [this guide](./run-a-validator.md#option-1-automatic-script))
+* [Docker](#docker-installs)
+* [Manual](#manual-installs)
+
+# Automated script installs
+
+Run the following command on your server:
+
+```
+curl -sSLO https://raw.githubusercontent.com/liberland/liberland_substrate/main/substrate/scripts/install/install.sh
+bash install.sh
+```
+
+The installer will detect existing install and perform the required updates without wiping any data or keys. If asked about which network to use - make sure you choose the correct one.
+
+# Docker installs
+
+You need to pull the latest image and recreate your container.
+
+If you followed the [Complete example of running a validator on mainnet](../dev/docker.md) guide, follow these steps:
+
+1. Pull the latest image:
+    ```
+    docker pull liberland/blockchain-node:latest
+    ```
+2. Stop and remove the old container. If you followed the guide, it won't remove any data or keys:
+    ```
+    docker stop liberland && docker rm liberland
+    ```
+3. Recreate the container:
+    ```
+    docker run --name liberland -d --network=host --restart always -v $HOME/liberland_data:/data liberland/blockchain-node:latest -d /data --chain /specs/mainnet.raw.json --validator
+    ```
+
+# Manual installs
+
+If you've installed manually, you need to:
+1. Download latest node binary (`linux_x86_build`) from the [releases page](https://github.com/liberland/liberland_substrate/releases)
+2. Download latest chain spec (`mainnet.raw.json`) from the [releases page](https://github.com/liberland/liberland_substrate/releases)
+3. Stop your node
+4. Replace the binary and spec files you're using with the downloaded ones
+5. Restart your node

--- a/blockchain/for-validators-nominators-and-stakers/using_prebuilt_binary.md
+++ b/blockchain/for-validators-nominators-and-stakers/using_prebuilt_binary.md
@@ -1,25 +1,14 @@
 # Using prebuilt binary
 
-## Download chain spec and node binary
+## Download node binary
 
+Download the latest binary (`linux_x86_build` file) from [GitHub Releases](https://github.com/liberland/liberland_substrate/releases).
 ```
 user@host:~$ mkdir -p liberland/
 user@host:~$ cd liberland/
-user@host:~/liberland$ wget https://github.com/liberland/liberland_substrate/releases/download/v8.1.0/linux_x86_build -O node
-user@host:~/liberland$ wget https://github.com/liberland/liberland_substrate/releases/download/v8.1.0/mainnet.raw.json
-user@host:~/liberland$ wget https://github.com/liberland/liberland_substrate/releases/download/v6.0.0/bastiat.raw.json
+user@host:~/liberland$ mv ~/Downloads/linux_x86_build -O node  # adjust path as needed
 user@host:~/liberland$ chmod +x node
 ```
-
-After downloading verify files integrity. Checksums should match with this output:
-```
-user@host:~/liberland$ sha256sum node mainnet.raw.json bastiat.raw.json 
-1331ca6064b41faad7d245e7fed434d54110f5d54b58763434fb53246e09f45b  node
-dbf1e9cbba193c6e6096b21c3b865ed82b3de6fca2643cf93141ac891a13ead7  mainnet.raw.json
-645df3a7c84ed64e3162cc7155624268fcb09a6dcde12b88bb8db8b2bfeec882  bastiat.raw.json
-```
-
-If not, abort and contact dev team.
 
 ## Run node
 
@@ -27,13 +16,13 @@ Make sure you replace `DATA_DIR` with a path to directory that can store at leas
 
 ```
 user@host:~/liberland$ ./node \
-    --chain NETWORK.raw.json \
+    --chain NETWORK \
     --validator \
     -d DATA_DIR
 ```
 
 Note:
-* *DO NOT* expose your validators RPC ports (9933 and 9944 by default) publicly on the internet. Treat validators with more care than full nodes.
+* *DO NOT* expose your validators RPC port (9944 by default) publicly on the internet. Treat validators with more care than full nodes.
 * You *do not* need to a run a validator to earn LLD staking rewards. As a user you can simply become a nominator and stake your coins without needing to run a validator.
 
 ## Optional: making it a system service
@@ -41,18 +30,18 @@ Note:
 To save the trouble of debugging the process, make sure that the following command that you are passing to it will work. Use absolute path to your `node` binary.
 
 ```
-/home/user/liberland/node --chain bastiat.raw.json -d /data/liberland_node --validator
+/home/user/liberland/node --chain bastiat -d /data/liberland_node --validator
 ```
 
 After verifying that your node works, it is recommended to do this step as a system process. On ubuntu, it would look something like:
 
 ```
-sudo systemctl edit --force --full liberland_validator.service
+sudo systemctl edit --force --full liberland-validator.service
 ```
 
 Then edit the file created, it should look similar to this example. Make sure:
 * insert the correct path to liberland node on your machine (the `/home/user/liberland` in example), both in `ExecStart` and `WorkingDirectory`
-* if setting up mainnet validator, replace `bastiat.raw.json` with `mainnet.raw.json`
+* if setting up mainnet validator, replace `bastiat` with `mainnet`
 * replace `/data/liberland_node` with path to directory that exists and can store few gigabytes of data.
 
 ```                            
@@ -60,7 +49,7 @@ Then edit the file created, it should look similar to this example. Make sure:
 Description=Liberland Validator
 
 [Service]
-ExecStart=/home/user/liberland/node --chain bastiat.raw.json -d /data/liberland_node --validator
+ExecStart=/home/user/liberland/node --chain bastiat -d /data/liberland_node --validator
 Restart=always
 RestartSec=120
 WorkingDirectory=/home/user/liberland
@@ -71,13 +60,13 @@ WantedBy=multi-user.target
 
 Save the file and then:
 ````
-sudo systemctl enable liberland_validator.service
-sudo systemctl start liberland_validator.service
+sudo systemctl enable liberland-validator.service
+sudo systemctl start liberland-validator.service
 ````
 
 and verify it works with
 ```
-sudo systemctl status liberland_validator.service
+sudo systemctl status liberland-validator.service
 ```
 
 ## Generate session keys

--- a/blockchain/for-validators-nominators-and-stakers/using_source.md
+++ b/blockchain/for-validators-nominators-and-stakers/using_source.md
@@ -2,9 +2,9 @@
 
 If you want to build from source instead of using prebuilt binary:
 
-1. Checkout the `v21.0.0` tag of repo:
+1. Checkout the `v25.0.0` tag of repo:
     ```
-    git clone https://github.com/liberland/liberland_substrate.git --depth 1 -b v21.0.0
+    git clone https://github.com/liberland/liberland_substrate.git --depth 1 -b v25.0.0
     cd liberland_substrate
     ```
 2. Build the code - see [Build, run & test using source code](../dev/dev.md) guide. Only follow up to the end of **Build the node**.

--- a/blockchain/for-validators-nominators-and-stakers/using_source.md
+++ b/blockchain/for-validators-nominators-and-stakers/using_source.md
@@ -2,17 +2,15 @@
 
 If you want to build from source instead of using prebuilt binary:
 
-1. Checkout the `v6.0.0` tag of repo:
+1. Checkout the `v21.0.0` tag of repo:
     ```
-    git clone https://github.com/liberland/liberland_substrate.git --depth 1 -b v6.0.0
+    git clone https://github.com/liberland/liberland_substrate.git --depth 1 -b v21.0.0
     cd liberland_substrate
     ```
 2. Build the code - see [Build, run & test using source code](../dev/dev.md) guide. Only follow up to the end of **Build the node**.
 3. Copy the relevant files:
     ```
     cp ./target/release/substrate node
-    cp specs/bastiat.raw.json bastiat.raw.json
-    cp specs/mainnet.raw.json mainnet.raw.json
     ```
 
 ## Run node
@@ -21,13 +19,13 @@ Make sure you replace `DATA_DIR` with a path to directory that can store at leas
 
 ```
 user@host:~/liberland$ ./node \
-    --chain NETWORK.raw.json \
+    --chain NETWORK \
     --validator \
     -d DATA_DIR
 ```
 
 Note:
-* *DO NOT* expose your validators RPC ports (9933 and 9944 by default) publicly on the internet. Treat validators with more care than full nodes.
+* *DO NOT* expose your validators RPC port (9944 by default) publicly on the internet. Treat validators with more care than full nodes.
 * You *do not* need to a run a validator to earn LLD staking rewards. As a user you can simply become a nominator and stake your coins without needing to run a validator.
 
 ## Optional: making it a system service
@@ -35,18 +33,18 @@ Note:
 To save the trouble of debugging the process, make sure that the following command that you are passing to it will work. Use absolute path to your `node` binary.
 
 ```
-/home/user/liberland/node --chain bastiat.raw.json -d /data/liberland_node --validator
+/home/user/liberland/node --chain bastiat -d /data/liberland_node --validator
 ```
 
 After verifying that your node works, it is recommended to do this step as a system process. On ubuntu, it would look something like:
 
 ```
-sudo systemctl edit --force --full liberland_validator.service
+sudo systemctl edit --force --full liberland-validator.service
 ```
 
 Then edit the file created, it should look similar to this example. Make sure:
 * insert the correct path to liberland node on your machine (the `/home/user/liberland` in example), both in `ExecStart` and `WorkingDirectory`
-* if setting up mainnet validator, replace `bastiat.raw.json` with `mainnet.raw.json`
+* if setting up mainnet validator, replace `bastiat` with `mainnet`
 * replace `/data/liberland_node` with path to directory that exists and can store few gigabytes of data.
 
 ```                            
@@ -54,7 +52,7 @@ Then edit the file created, it should look similar to this example. Make sure:
 Description=Liberland Validator
 
 [Service]
-ExecStart=/home/user/liberland/node --chain bastiat.raw.json -d /data/liberland_node --validator
+ExecStart=/home/user/liberland/node --chain bastiat -d /data/liberland_node --validator
 Restart=always
 RestartSec=120
 WorkingDirectory=/home/user/liberland
@@ -65,13 +63,13 @@ WantedBy=multi-user.target
 
 Save the file and then:
 ````
-sudo systemctl enable liberland_validator.service
-sudo systemctl start liberland_validator.service
+sudo systemctl enable liberland-validator.service
+sudo systemctl start liberland-validator.service
 ````
 
 and verify it works with
 ```
-sudo systemctl status liberland_validator.service
+sudo systemctl status liberland-validator.service
 ```
 ## Generate session keys
 


### PR DESCRIPTION
In addition to crash recovery stuff, it also changes all docs to stop using JSON specs (as we're dropping them to make crash recovery easier).